### PR TITLE
fix: rename nvim_lsp to lspconfig

### DIFF
--- a/lua/rooter.lua
+++ b/lua/rooter.lua
@@ -1,4 +1,4 @@
-local nvim_lsp = require('nvim_lsp')
+local nvim_lsp = require('lspconfig')
 local api = vim.api
 
 local M = {}


### PR DESCRIPTION
[Make compatible with upstream](https://github.com/neovim/nvim-lspconfig/pull/348)

change the `require` module name from `nvim_lsp` to `lspconfig`